### PR TITLE
Fix MACOSX_RPATH is not specified for the following targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
+
+if (POLICY CMP0042)
+	# Newer cmake on MacOS should use @rpath
+	cmake_policy (SET CMP0042 NEW)
+endif ()
+
 project(liboca C)
 
 #


### PR DESCRIPTION
Fixes:

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   liboca-shared

This warning is for project developers.  Use -Wno-dev to suppress it.
```
